### PR TITLE
Removed referance to Firefox OS Marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ npm-debug.log
 # Generated
 dist/
 package.zip
+
+# macOS
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 Run Ruby in your Firefox OS smartphone.
 
 
-## Usage
-
-Just search the [Marketplace](https://marketplace.firefox.com) for "Ruby2Go".
-
-
 ## Contributing
 
 I'm using Bower and Gulp, so grab these before proceeding.


### PR DESCRIPTION
#1 Removed references to FireFox OS, also added .DS_Store files to .gitignore. (.DS_Store is specific to mac.)